### PR TITLE
fix short answer and click automatically

### DIFF
--- a/zybooks-mcq.js
+++ b/zybooks-mcq.js
@@ -75,11 +75,13 @@ window.doShortAnswers = async () => {
 
       console.log(answer)
 
-      const input = q.querySelector(".ember-text-area.zb-text-area")
+      const input = q.querySelector("input.zb-input")
       input.value = answer
       input.textContent = answer
+      const event = new Event('input', { bubbles: true })
+      input.dispatchEvent(event)
 
-      // q.querySelector("button.check-button").click()
+      q.querySelector("button.check-button").click()
       await sleep(200)
     }
 


### PR DESCRIPTION
You are a legend for making this. Anyway:

PR tested on ungoogled-chromium 128, I hope zybook doesn't change behavior based on browser???

name of short answer input seems to have changed so I switched that and then added empty event so that manual submit is not needed :)

Drag+Drop still seems to be broken though, dunno how to fix that one